### PR TITLE
解决idea editor载入内容换行为crlf的时候报错

### DIFF
--- a/src/main/java/com/chuntung/plugin/gistsnippet/view/InsertGistDialog.java
+++ b/src/main/java/com/chuntung/plugin/gistsnippet/view/InsertGistDialog.java
@@ -364,7 +364,7 @@ public class InsertGistDialog extends DialogWrapper {
 
                 EditorHighlighterFactory highlighterFactory = EditorHighlighterFactory.getInstance();
                 FileType fileType = FileNodeDTO.getFileType(fileDTO);
-                editor.getDocument().setText(fileDTO.getContent());
+                editor.getDocument().setText(fileDTO.getContent().replaceAll("\\r\\n?", "\n"));
                 ((EditorEx) editor).setHighlighter(highlighterFactory.createEditorHighlighter(project, fileType));
                 editorFileUrl = fileDTO.getRawUrl();
 


### PR DESCRIPTION
如果提交到gist的内容换行符为crlf，插件载入内容就会报错
目前没有找到很好的办法让idea的editor支持lf和crlf，所以采取了比较笨的办法，在加载之前将crlf替换为lf